### PR TITLE
Typeclass

### DIFF
--- a/.idea/jsonSchemas.xml
+++ b/.idea/jsonSchemas.xml
@@ -1,45 +1,46 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="JsonSchemaMappingsProjectConfiguration">
-    <state>
-      <map>
-        <entry key="Biome">
-          <value>
-            <SchemaInfo>
-              <option name="generatedName" value="New Schema" />
-              <option name="name" value="Biome" />
-              <option name="relativePathToSchema" value="https://biomejs.dev/schemas/1.7.3/schema.json" />
-              <option name="schemaVersion" value="JSON Schema version 7" />
-              <option name="patterns">
-                <list>
-                  <Item>
-                    <option name="path" value="biome.json" />
-                  </Item>
-                  <Item>
-                    <option name="path" value="biome.jsonc" />
-                  </Item>
-                </list>
-              </option>
-            </SchemaInfo>
-          </value>
-        </entry>
-        <entry key="Deno Config (deno.json)">
-          <value>
-            <SchemaInfo>
-              <option name="name" value="Deno Config (deno.json)" />
-              <option name="relativePathToSchema" value="https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json" />
-              <option name="applicationDefined" value="true" />
-              <option name="patterns">
-                <list>
-                  <Item>
-                    <option name="path" value="deno.jsonc" />
-                  </Item>
-                </list>
-              </option>
-            </SchemaInfo>
-          </value>
-        </entry>
-      </map>
-    </state>
-  </component>
+    <component name="JsonSchemaMappingsProjectConfiguration">
+        <state>
+            <map>
+                <entry key="Biome">
+                    <value>
+                        <SchemaInfo>
+                            <option name="generatedName" value="New Schema"/>
+                            <option name="name" value="Biome"/>
+                            <option name="relativePathToSchema" value="https://biomejs.dev/schemas/1.8.0/schema.json"/>
+                            <option name="schemaVersion" value="JSON Schema version 7"/>
+                            <option name="patterns">
+                                <list>
+                                    <Item>
+                                        <option name="path" value="biome.json"/>
+                                    </Item>
+                                    <Item>
+                                        <option name="path" value="biome.jsonc"/>
+                                    </Item>
+                                </list>
+                            </option>
+                        </SchemaInfo>
+                    </value>
+                </entry>
+                <entry key="Deno Config (deno.json)">
+                    <value>
+                        <SchemaInfo>
+                            <option name="name" value="Deno Config (deno.json)"/>
+                            <option name="relativePathToSchema"
+                                    value="https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json"/>
+                            <option name="applicationDefined" value="true"/>
+                            <option name="patterns">
+                                <list>
+                                    <Item>
+                                        <option name="path" value="deno.jsonc"/>
+                                    </Item>
+                                </list>
+                            </option>
+                        </SchemaInfo>
+                    </value>
+                </entry>
+            </map>
+        </state>
+    </component>
 </project>

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.7.3/schema.json",
+	"$schema": "https://biomejs.dev/schemas/1.8.0/schema.json",
 	"formatter": {
 		"enabled": true,
 		"indentStyle": "tab",
@@ -10,14 +10,14 @@
 	},
 	"javascript": {
 		"formatter": {
-			"arrowParentheses": "asNeeded",
+			"arrowParentheses": "always",
 			"enabled": true,
 			"indentStyle": "tab",
 			"lineEnding": "lf",
 			"quoteProperties": "asNeeded",
 			"quoteStyle": "single",
 			"semicolons": "asNeeded",
-			"trailingComma": "all"
+			"trailingCommas": "all"
 		}
 	},
 	"linter": {

--- a/deno.lock
+++ b/deno.lock
@@ -7,7 +7,7 @@
       "jsr:@std/expect": "jsr:@std/expect@0.224.2",
       "jsr:@std/internal@^1.0.0": "jsr:@std/internal@1.0.0",
       "jsr:@std/testing": "jsr:@std/testing@0.224.0",
-      "npm:@biomejs/biome": "npm:@biomejs/biome@1.7.3",
+      "npm:@biomejs/biome": "npm:@biomejs/biome@1.8.0",
       "npm:expect-type@0.19.0": "npm:expect-type@0.19.0"
     },
     "jsr": {
@@ -32,49 +32,49 @@
       }
     },
     "npm": {
-      "@biomejs/biome@1.7.3": {
-        "integrity": "sha512-ogFQI+fpXftr+tiahA6bIXwZ7CSikygASdqMtH07J2cUzrpjyTMVc9Y97v23c7/tL1xCZhM+W9k4hYIBm7Q6cQ==",
+      "@biomejs/biome@1.8.0": {
+        "integrity": "sha512-34xcE2z8GWrIz1sCFEmlHT/+4d+SN7YOqqvzlAKXKvaWPRJ2/NUwxPbRsP01P9QODkQ5bvGvc9rpBihmP+7RJQ==",
         "dependencies": {
-          "@biomejs/cli-darwin-arm64": "@biomejs/cli-darwin-arm64@1.7.3",
-          "@biomejs/cli-darwin-x64": "@biomejs/cli-darwin-x64@1.7.3",
-          "@biomejs/cli-linux-arm64": "@biomejs/cli-linux-arm64@1.7.3",
-          "@biomejs/cli-linux-arm64-musl": "@biomejs/cli-linux-arm64-musl@1.7.3",
-          "@biomejs/cli-linux-x64": "@biomejs/cli-linux-x64@1.7.3",
-          "@biomejs/cli-linux-x64-musl": "@biomejs/cli-linux-x64-musl@1.7.3",
-          "@biomejs/cli-win32-arm64": "@biomejs/cli-win32-arm64@1.7.3",
-          "@biomejs/cli-win32-x64": "@biomejs/cli-win32-x64@1.7.3"
+          "@biomejs/cli-darwin-arm64": "@biomejs/cli-darwin-arm64@1.8.0",
+          "@biomejs/cli-darwin-x64": "@biomejs/cli-darwin-x64@1.8.0",
+          "@biomejs/cli-linux-arm64": "@biomejs/cli-linux-arm64@1.8.0",
+          "@biomejs/cli-linux-arm64-musl": "@biomejs/cli-linux-arm64-musl@1.8.0",
+          "@biomejs/cli-linux-x64": "@biomejs/cli-linux-x64@1.8.0",
+          "@biomejs/cli-linux-x64-musl": "@biomejs/cli-linux-x64-musl@1.8.0",
+          "@biomejs/cli-win32-arm64": "@biomejs/cli-win32-arm64@1.8.0",
+          "@biomejs/cli-win32-x64": "@biomejs/cli-win32-x64@1.8.0"
         }
       },
-      "@biomejs/cli-darwin-arm64@1.7.3": {
-        "integrity": "sha512-eDvLQWmGRqrPIRY7AIrkPHkQ3visEItJKkPYSHCscSDdGvKzYjmBJwG1Gu8+QC5ed6R7eiU63LEC0APFBobmfQ==",
+      "@biomejs/cli-darwin-arm64@1.8.0": {
+        "integrity": "sha512-dBAYzfIJ1JmWigKlWourT3sJ3I60LZPjqNwwlsyFjiv5AV7vPeWlHVVIImV2BpINwNjZQhpXnwDfVnGS4vr7AA==",
         "dependencies": {}
       },
-      "@biomejs/cli-darwin-x64@1.7.3": {
-        "integrity": "sha512-JXCaIseKRER7dIURsVlAJacnm8SG5I0RpxZ4ya3dudASYUc68WGl4+FEN03ABY3KMIq7hcK1tzsJiWlmXyosZg==",
+      "@biomejs/cli-darwin-x64@1.8.0": {
+        "integrity": "sha512-ZTTSD0bP0nn9UpRDGQrQNTILcYSj+IkxTYr3CAV64DWBDtQBomlk2oVKWzDaA1LOhpAsTh0giLCbPJaVk2jfMQ==",
         "dependencies": {}
       },
-      "@biomejs/cli-linux-arm64-musl@1.7.3": {
-        "integrity": "sha512-c8AlO45PNFZ1BYcwaKzdt46kYbuP6xPGuGQ6h4j3XiEDpyseRRUy/h+6gxj07XovmyxKnSX9GSZ6nVbZvcVUAw==",
+      "@biomejs/cli-linux-arm64-musl@1.8.0": {
+        "integrity": "sha512-+ee/pZWsvhDv6eRI00krRNSgAg8DKSxzOv3LUsCjto6N1VzqatTASeQv2HRfG1nitf79rRKM75LkMJbqEfiKww==",
         "dependencies": {}
       },
-      "@biomejs/cli-linux-arm64@1.7.3": {
-        "integrity": "sha512-phNTBpo7joDFastnmZsFjYcDYobLTx4qR4oPvc9tJ486Bd1SfEVPHEvJdNJrMwUQK56T+TRClOQd/8X1nnjA9w==",
+      "@biomejs/cli-linux-arm64@1.8.0": {
+        "integrity": "sha512-cx725jTlJS6dskvJJwwCQaaMRBKE2Qss7ukzmx27Rn/DXRxz6tnnBix4FUGPf1uZfwrERkiJlbWM05JWzpvvXg==",
         "dependencies": {}
       },
-      "@biomejs/cli-linux-x64-musl@1.7.3": {
-        "integrity": "sha512-UdEHKtYGWEX3eDmVWvQeT+z05T9/Sdt2+F/7zmMOFQ7boANeX8pcO6EkJPK3wxMudrApsNEKT26rzqK6sZRTRA==",
+      "@biomejs/cli-linux-x64-musl@1.8.0": {
+        "integrity": "sha512-VPA4ocrAOak50VYl8gOAVnjuFFDpIUolShntc/aWM0pZfSIMbRucxnrfUfp44EVwayxjK6ruJTR5xEWj93WvDA==",
         "dependencies": {}
       },
-      "@biomejs/cli-linux-x64@1.7.3": {
-        "integrity": "sha512-vnedYcd5p4keT3iD48oSKjOIRPYcjSNNbd8MO1bKo9ajg3GwQXZLAH+0Cvlr+eMsO67/HddWmscSQwTFrC/uPA==",
+      "@biomejs/cli-linux-x64@1.8.0": {
+        "integrity": "sha512-cmgmhlD4QUxMhL1VdaNqnB81xBHb3R7huVNyYnPYzP+AykZ7XqJbPd1KcWAszNjUk2AHdx0aLKEBwCOWemxb2g==",
         "dependencies": {}
       },
-      "@biomejs/cli-win32-arm64@1.7.3": {
-        "integrity": "sha512-unNCDqUKjujYkkSxs7gFIfdasttbDC4+z0kYmcqzRk6yWVoQBL4dNLcCbdnJS+qvVDNdI9rHp2NwpQ0WAdla4Q==",
+      "@biomejs/cli-win32-arm64@1.8.0": {
+        "integrity": "sha512-J31spvlh39FfRHQacYXxJX9PvTCH/a8+2Jx9D1lxw+LSF0JybqZcw/4JrlFUWUl4kF3yv8AuYUK0sENScc3g9w==",
         "dependencies": {}
       },
-      "@biomejs/cli-win32-x64@1.7.3": {
-        "integrity": "sha512-ZmByhbrnmz/UUFYB622CECwhKIPjJLLPr5zr3edhu04LzbfcOrz16VYeNq5dpO1ADG70FORhAJkaIGdaVBG00w==",
+      "@biomejs/cli-win32-x64@1.8.0": {
+        "integrity": "sha512-uPHHvu76JC1zYe9zZDcOU9PAg+1MZmPuNgWkb5jljaDeATvzLFPB+0nuJTilf603LXL+E8IdPQAO61Wy2VuEJA==",
         "dependencies": {}
       },
       "expect-type@0.19.0": {

--- a/src/internal/hkt.ts
+++ b/src/internal/hkt.ts
@@ -60,20 +60,20 @@ export interface TypeLambda {
 export type Kind<F extends TypeLambda, In, Out2, Out1, Target> = F extends {
 	readonly type: unknown
 }
-	? // If F has a type property, it means it is a concrete type lambda (e.g., F = ArrayTypeLambda).
-		// The intersection allows us to obtain the result of applying F to Target.
-		(F & {
-			readonly In: In
-			readonly Out2: Out2
-			readonly Out1: Out1
-			readonly Target: Target
-		})['type']
-	: // If F is generic, we must explicitly specify all of its type parameters
-		// to ensure that none are omitted from type checking.
-		{
-			readonly F: F
-			readonly In: Types.Contravariant<In>
-			readonly Out2: Types.Covariant<Out2>
-			readonly Out1: Types.Covariant<Out1>
-			readonly Target: Types.Invariant<Target>
-		}
+	// If F has a type property, it means it is a concrete type lambda (e.g., F = ArrayTypeLambda).
+	// The intersection allows us to obtain the result of applying F to Target.
+	? (F & {
+		readonly In: In
+		readonly Out2: Out2
+		readonly Out1: Out1
+		readonly Target: Target
+	})['type']
+	// If F is generic, we must explicitly specify all of its type parameters
+	// to ensure that none are omitted from type checking.
+	: {
+		readonly F: F
+		readonly In: Types.Contravariant<In>
+		readonly Out2: Types.Covariant<Out2>
+		readonly Out1: Types.Covariant<Out1>
+		readonly Target: Types.Invariant<Target>
+	}

--- a/src/internal/hkt.ts
+++ b/src/internal/hkt.ts
@@ -1,0 +1,79 @@
+import type { Types } from './types.ts'
+
+export declare const URI: unique symbol
+
+export interface TypeClass<F extends TypeLambda> {
+	/**
+	 * To improve inference it is necessary to mention the F parameter inside it otherwise it will be lost, we can do so by adding an optional property
+	 */
+	readonly [URI]?: F
+}
+
+/**
+ * Type Lambdas are a way to define type-level functions in TypeScript, which are not natively supported by the language.
+ *
+ * A Type Lambda, like `Target -> F<Target>`, essentially defines a function that operates on types and returns other types. Let's break down this concept:
+ * ```
+ * Target -> Array<Target>
+ * ```
+ * In this example, the Type Lambda maps the input type `Target` to the output type `Array<Target>`. It's like defining a rule that transforms one type into another.
+ *
+ * @see https://effect.website/docs/other/behaviour/hkt#type-lambdas
+ */
+export interface TypeLambda {
+	/**
+	 * (Contravariant):
+	 * This type parameter is used for contravariant operations, which means that it accepts input types that are more general or broader than the original type.
+	 */
+	readonly In: unknown
+
+	/**
+	 * (Covariant):
+	 * Out2 represents a covariant type parameter.
+	 * It allows for operations where the output type is more specific or narrower than the original type.
+	 */
+	readonly Out2: unknown
+
+	/**
+	 * (Covariant):
+	 * Similar to Out2, Out1 is a covariant type parameter, enabling operations that result in a more specific output type.
+	 */
+	readonly Out1: unknown
+
+	/**
+	 * (Invariant):
+	 * The Target type parameter remains invariant, meaning that it maintains the exact type as the original without any variation.
+	 */
+	readonly Target: unknown
+}
+
+/**
+ * Represents a generic type `Kind` that can be applied to specific type arguments.
+ * It allows the user to obtain the result of applying the `Kind` to a target type.
+ *
+ * @template F - The type parameter for the `Kind` class, can be either a concrete type or a generic type.
+ * @template In - The contravariant input type.
+ * @template Out2 - The covariant second output type.
+ * @template Out1 - The covariant first output type.
+ * @template Target - The invariant target type.
+ */
+export type Kind<F extends TypeLambda, In, Out2, Out1, Target> = F extends {
+	readonly type: unknown
+}
+	? // If F has a type property, it means it is a concrete type lambda (e.g., F = ArrayTypeLambda).
+		// The intersection allows us to obtain the result of applying F to Target.
+		(F & {
+			readonly In: In
+			readonly Out2: Out2
+			readonly Out1: Out1
+			readonly Target: Target
+		})['type']
+	: // If F is generic, we must explicitly specify all of its type parameters
+		// to ensure that none are omitted from type checking.
+		{
+			readonly F: F
+			readonly In: Types.Contravariant<In>
+			readonly Out2: Types.Covariant<Out2>
+			readonly Out1: Types.Covariant<Out1>
+			readonly Target: Types.Invariant<Target>
+		}

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -63,4 +63,19 @@ export declare namespace Types {
 		[K in keyof A]: A[K]
 	} extends infer B ? B
 		: never
+
+	/**
+	 * Invariant helper.
+	 */
+	export type Invariant<A> = (_: A) => A
+
+	/**
+	 * Covariant helper.
+	 */
+	export type Covariant<A> = (_: never) => A
+
+	/**
+	 * Contravariant helper.
+	 */
+	export type Contravariant<A> = (_: A) => void
 }

--- a/src/option/option.test.ts
+++ b/src/option/option.test.ts
@@ -209,21 +209,43 @@ describe('Option', () => {
 		})
 	})
 
-	describe('map', () => {
-		test('static', () => {
-			const f: (n: number) => number = (n) => n * 2
-			const g: (n: number) => string = (n) => n.toString()
-			Util.deepStrictEqual(pipe(Option.Some(1), Option.map(f)), Option.Some(2))
-			expectTypeOf(Option.map(f)(Option.Some(1))).toEqualTypeOf<Option.Type<number>>()
+	describe('Covariant', () => {
+		describe('map', () => {
+			test('static', () => {
+				const f: (n: number) => number = (n) => n * 2
+				const g: (n: number) => string = (n) => n.toString()
+				Util.deepStrictEqual(pipe(Option.Some(1), Option.map(f)), Option.Some(2))
+				expectTypeOf(Option.map(f)(Option.Some(1))).toEqualTypeOf<Option.Type<number>>()
 
-			Util.deepStrictEqual(pipe(Option.Some(42), Option.map(g)), Option.Some('42'))
-			expectTypeOf(Option.map(g)(Option.Some(1))).toEqualTypeOf<Option.Type<string>>()
+				Util.deepStrictEqual(pipe(Option.Some(42), Option.map(g)), Option.Some('42'))
+				expectTypeOf(Option.map(g)(Option.Some(1))).toEqualTypeOf<Option.Type<string>>()
 
-			Util.deepStrictEqual(pipe(Option.None<number>(), Option.map(f)), Option.None<number>())
-			Util.deepStrictEqual(pipe(Option.None<number>(), Option.map(g)), Option.None<string>())
+				Util.deepStrictEqual(
+					pipe(Option.None<number>(), Option.map(f)),
+					Option.None<number>(),
+				)
+				Util.deepStrictEqual(
+					pipe(Option.None<number>(), Option.map(g)),
+					Option.None<string>(),
+				)
+			})
+
+			test.skip('instance', () => {})
 		})
 
-		test.skip('instance', () => {})
+		describe('imap', () => {
+			const f: (n: number) => string = (n) => n.toString()
+			const g: (s: string) => number = (s) => Number(s)
+			const someNumber = Option.of(1)
+			const noneNumber = Option.None<number>()
+
+			test('static', () => {
+				Util.optionEqual(pipe(someNumber, Option.imap(f, g)), Option.of('1'))
+				Util.optionEqual(pipe(noneNumber, Option.imap(f, g)), Option.None<string>())
+			})
+
+			test.skip('instance', () => {})
+		})
 
 		describe('Functor laws', () => {
 			it('Identity ', () => {

--- a/src/option/option.test.ts
+++ b/src/option/option.test.ts
@@ -213,7 +213,7 @@ describe('Option', () => {
 
 	describe('flatMap', () => {
 		const f = (n: number) => Option.Some(n * 2)
-		const g = () => Option.None()
+		const g = () => Option.None<string>()
 
 		test('static', () => {
 			Util.deepStrictEqual(pipe(Option.Some(1), Option.flatMap(f)), Option.Some(2))

--- a/src/option/option.test.ts
+++ b/src/option/option.test.ts
@@ -1,23 +1,11 @@
 import { expectTypeOf } from 'npm:expect-type@0.19.0'
-import { assertEquals, assertStrictEquals, equal } from 'jsr:@std/assert'
+import { equal } from 'jsr:@std/assert'
 import { expect } from 'jsr:@std/expect'
 import { describe, it, test } from 'jsr:@std/testing/bdd'
 
 import { type Lazy, pipe } from '../internal/function.ts'
+import { Util } from '../test/utils.ts'
 import { Option } from './option.ts'
-
-// deno-lint-ignore no-namespace
-namespace Util {
-	// biome-ignore lint/suspicious/noExportsInTest: <explanation>
-	export const deepStrictEqual = <A>(actual: A, expected: A) => {
-		assertEquals(actual, expected)
-	}
-
-	// biome-ignore lint/suspicious/noExportsInTest: <explanation>
-	export const optionEqual = <A>(actual: Option.Type<A>, expected: Option.Type<A>) => {
-		assertStrictEquals(actual.equals(expected), true)
-	}
-}
 
 describe('Option', () => {
 	describe('constructors', () => {

--- a/src/option/option.test.ts
+++ b/src/option/option.test.ts
@@ -211,6 +211,44 @@ describe('Option', () => {
 		})
 	})
 
+	describe('map', () => {
+		test('static', () => {
+			const f: (n: number) => number = (n) => n * 2
+			const g: (n: number) => string = (n) => n.toString()
+			Util.deepStrictEqual(pipe(Option.Some(1), Option.map(f)), Option.Some(2))
+			expectTypeOf(Option.map(f)(Option.Some(1))).toEqualTypeOf<Option.Type<number>>()
+
+			Util.deepStrictEqual(pipe(Option.Some(42), Option.map(g)), Option.Some('42'))
+			expectTypeOf(Option.map(g)(Option.Some(1))).toEqualTypeOf<Option.Type<string>>()
+
+			Util.deepStrictEqual(pipe(Option.None<number>(), Option.map(f)), Option.None<number>())
+			Util.deepStrictEqual(pipe(Option.None<number>(), Option.map(g)), Option.None<string>())
+		})
+
+		test.skip('instance', () => {})
+
+		describe('Functor laws', () => {
+			it('Identity ', () => {
+				const identity = <A>(a: A): A => a
+				const Fa: Option.Type<number> = Option.Some(1)
+				Util.optionEqual(pipe(Fa, Option.map(identity)), Fa)
+			})
+
+			it('Composition ', () => {
+				const Fa: Option.Type<number> = Option.Some(0)
+				const f: (a: number) => string = (a) => String(a)
+				const g: (b: string) => boolean = (b) => Boolean(b)
+				Util.optionEqual(
+					pipe(Fa, Option.map(f), Option.map(g)),
+					pipe(
+						Fa,
+						Option.map((a) => g(f(a))),
+					),
+				)
+			})
+		})
+	})
+
 	describe('flatMap', () => {
 		const f = (n: number) => Option.Some(n * 2)
 		const g = () => Option.None<string>()

--- a/src/option/option.test.ts
+++ b/src/option/option.test.ts
@@ -28,6 +28,16 @@ describe('Option', () => {
 			}).toThrow('Option is not meant to be instantiated directly')
 		})
 
+		test('of', () => {
+			const some = Option.of(1)
+			expectTypeOf(some).toEqualTypeOf<Option.Type<number>>()
+			expect(some._tag).toBe('Some')
+			expect(some.get()).toBe(1)
+
+			expectTypeOf(Option.of(null)).toEqualTypeOf<Option.Type<null>>() // should we allow this?
+			expectTypeOf(Option.of(undefined)).toEqualTypeOf<Option.Type<undefined>>() // should we allow this? maybe of should not lift nullable values?
+		})
+
 		test('Some', () => {
 			const some = Option.Some(1)
 			expect(some._tag).toBe('Some')

--- a/src/option/option.test.ts
+++ b/src/option/option.test.ts
@@ -97,7 +97,7 @@ describe('Option', () => {
 
 			const noneOfUnknown = Option.None()
 			const noneOfNumber = Option.None<number>()
-			expectTypeOf<Option.Value<typeof noneOfUnknown>>().toEqualTypeOf<unknown>()
+			expectTypeOf<Option.Value<typeof noneOfUnknown>>().toEqualTypeOf<never>()
 			expectTypeOf<Option.Value<typeof noneOfNumber>>().toEqualTypeOf<number>()
 
 			type Foo = { foo: string }
@@ -135,7 +135,7 @@ describe('Option', () => {
 		})
 
 		test('None', () => {
-			expect(Option.None().getOrElse(() => 2)).toBe(2)
+			expect(Option.None<number>().getOrElse(() => 2)).toBe(2)
 			expect(
 				Option.fromNullable<undefined | { foo: string }>(undefined).getOrElse(() => ({
 					foo: 'baz',
@@ -143,7 +143,7 @@ describe('Option', () => {
 			).toEqual({
 				foo: 'baz',
 			})
-			expect(Option.None().getOrElse(() => null)).toEqual(null)
+			expect(Option.None<null | unknown>().getOrElse(() => null)).toEqual(null)
 		})
 	})
 

--- a/src/option/option.test.ts
+++ b/src/option/option.test.ts
@@ -211,26 +211,28 @@ describe('Option', () => {
 
 	describe('Covariant', () => {
 		describe('map', () => {
-			test('static', () => {
-				const f: (n: number) => number = (n) => n * 2
-				const g: (n: number) => string = (n) => n.toString()
-				Util.deepStrictEqual(pipe(Option.Some(1), Option.map(f)), Option.Some(2))
-				expectTypeOf(Option.map(f)(Option.Some(1))).toEqualTypeOf<Option.Type<number>>()
+			const f: (n: number) => number = (n) => n * 2
+			const g: (n: number) => string = (n) => n.toString()
+			const someNumber = Option.of(1)
+			const noneNumber = Option.None<number>()
 
-				Util.deepStrictEqual(pipe(Option.Some(42), Option.map(g)), Option.Some('42'))
+			test('static', () => {
+				Util.optionEqual(pipe(someNumber, Option.map(f)), Option.of(2))
+				expectTypeOf(Option.map(f)(someNumber)).toEqualTypeOf<Option.Type<number>>()
+
+				Util.optionEqual(pipe(Option.Some(42), Option.map(g)), Option.Some('42'))
 				expectTypeOf(Option.map(g)(Option.Some(1))).toEqualTypeOf<Option.Type<string>>()
 
-				Util.deepStrictEqual(
-					pipe(Option.None<number>(), Option.map(f)),
-					Option.None<number>(),
-				)
-				Util.deepStrictEqual(
-					pipe(Option.None<number>(), Option.map(g)),
-					Option.None<string>(),
-				)
+				Util.optionEqual(pipe(noneNumber, Option.map(f)), noneNumber)
+				Util.optionEqual(pipe(noneNumber, Option.map(g)), Option.None<string>())
 			})
 
-			test.skip('instance', () => {})
+			test('instance', () => {
+				Util.optionEqual(someNumber.map(f), Option.of(2))
+				Util.optionEqual(Option.Some(42).map(g), Option.Some('42'))
+				Util.optionEqual(noneNumber.map(f), noneNumber)
+				Util.optionEqual(noneNumber.map(g), Option.None<string>())
+			})
 		})
 
 		describe('imap', () => {
@@ -244,7 +246,10 @@ describe('Option', () => {
 				Util.optionEqual(pipe(noneNumber, Option.imap(f, g)), Option.None<string>())
 			})
 
-			test.skip('instance', () => {})
+			test('instance', () => {
+				Util.optionEqual(someNumber.imap(f, g), Option.of('1'))
+				Util.optionEqual(noneNumber.imap(f, g), Option.None<string>())
+			})
 		})
 
 		describe('Functor laws', () => {

--- a/src/option/option.ts
+++ b/src/option/option.ts
@@ -2,7 +2,12 @@ import type { Equals } from '../internal/equals.ts'
 import type * as F from '../internal/function.ts'
 import type { TypeLambda } from '../internal/hkt.ts'
 import type { Inspectable } from '../internal/inspectable.ts'
-import type { FlatMapFluent, FlatMapPipable } from '../typeclass/flat-map.ts'
+import type { FlatMapPipeable } from '../typeclass/flat-map.ts'
+import type {
+	FlatMap,
+	// Covariant,
+	// Invariant
+} from '../typeclass/mod.ts'
 
 function format(x: unknown): string {
 	return JSON.stringify(x, null, 2)
@@ -64,8 +69,7 @@ interface OptionTypeLambda extends TypeLambda {
  * )
  * ```
  */
-export abstract class Option<out A>
-	implements Inspectable, Equals, FlatMapFluent<OptionTypeLambda> {
+export abstract class Option<out A> implements Inspectable, Equals, FlatMap<OptionTypeLambda> {
 	/**
 	 * The discriminant property that identifies the type of the `Option` instance.
 	 */
@@ -144,9 +148,9 @@ export abstract class Option<out A>
 	 * @returns A function that takes an Option and returns the result of applying `f` to this Option's value if the Option is nonempty. Otherwise, returns None.
 	 * @see  Option#flatMap
 	 */
-	public static flatMap: FlatMapPipable<OptionTypeLambda>['flatMap'] =
+	public static flatMap: FlatMapPipeable<OptionTypeLambda>['flatMap'] =
 		<A, B>(f: (a: A) => Option.Type<B>) => (self: Option.Type<A>): Option.Type<B> =>
-			self.isNone() ? Option.None() : f(self.get())
+			Option.isNone(self) ? Option.None() : f(self.get())
 
 	/**
 	 * Returns a new function that takes an Option and returns the result of applying `f` to Option's value if the Option is nonempty. Otherwise, evaluates expression `ifEmpty`.

--- a/src/option/option.ts
+++ b/src/option/option.ts
@@ -133,7 +133,7 @@ export abstract class Option<out A>
 	 *
 	 * @category constructors
 	 */
-	public static None<A>(): Option.Type<A> {
+	public static None<A = never>(): Option.Type<A> {
 		return None.getSingletonInstance<A>()
 	}
 

--- a/src/option/option.ts
+++ b/src/option/option.ts
@@ -15,7 +15,10 @@ function format(x: unknown): string {
 	return JSON.stringify(x, null, 2)
 }
 
-interface OptionTypeLambda extends TypeLambda {
+/**
+ * @internal
+ */
+export interface OptionTypeLambda extends TypeLambda {
 	readonly type: Option.Type<this['Target']>
 }
 

--- a/src/option/option.ts
+++ b/src/option/option.ts
@@ -1,9 +1,14 @@
 import type { Equals } from '../internal/equals.ts'
 import type * as F from '../internal/function.ts'
+import type { TypeLambda } from '../internal/hkt.ts'
 import type { Inspectable } from '../internal/inspectable.ts'
 
 function format(x: unknown): string {
 	return JSON.stringify(x, null, 2)
+}
+
+interface OptionTypeLambda extends TypeLambda {
+	readonly type: Option.Type<this['Target']>
 }
 
 /**

--- a/src/option/option.ts
+++ b/src/option/option.ts
@@ -2,6 +2,7 @@ import type { Equals } from '../internal/equals.ts'
 import type * as F from '../internal/function.ts'
 import type { TypeLambda } from '../internal/hkt.ts'
 import type { Inspectable } from '../internal/inspectable.ts'
+import type { CovariantPipeable } from '../typeclass/covariant.ts'
 import type { FlatMapPipeable } from '../typeclass/flat-map.ts'
 import type {
 	FlatMap,
@@ -321,6 +322,10 @@ export abstract class Option<out A> implements Inspectable, Equals, FlatMap<Opti
 	public static isSome<T>(self: Option.Type<T>): self is Some<T> {
 		return self instanceof Some
 	}
+
+	public static map: CovariantPipeable<OptionTypeLambda>['map'] =
+		<A, B>(f: (a: A) => B) => (self: Option.Type<A>): Option.Type<B> =>
+			Option.isNone(self) ? Option.None() : Option.Some(f(self.get()))
 
 	/**
 	 * Curried pattern matching for `Option` instances.

--- a/src/option/option.ts
+++ b/src/option/option.ts
@@ -3,7 +3,6 @@ import type * as F from '../internal/function.ts'
 import type { TypeLambda } from '../internal/hkt.ts'
 import type { Inspectable } from '../internal/inspectable.ts'
 import { type CovariantPipeable, imap } from '../typeclass/covariant.ts'
-import type { FlatMapPipeable } from '../typeclass/flat-map.ts'
 import type {
 	FlatMap,
 	// Covariant,
@@ -74,7 +73,8 @@ export interface OptionTypeLambda extends TypeLambda {
  * )
  * ```
  */
-export abstract class Option<out A> implements Inspectable, Equals, FlatMap<OptionTypeLambda> {
+export abstract class Option<out A>
+	implements Inspectable, Equals, FlatMap.Fluent<OptionTypeLambda> {
 	/**
 	 * The discriminant property that identifies the type of the `Option` instance.
 	 */
@@ -155,7 +155,7 @@ export abstract class Option<out A> implements Inspectable, Equals, FlatMap<Opti
 	 * @returns A function that takes an Option and returns the result of applying `f` to this Option's value if the Option is nonempty. Otherwise, returns None.
 	 * @see  Option#flatMap
 	 */
-	public static flatMap: FlatMapPipeable<OptionTypeLambda>['flatMap'] =
+	public static flatMap: FlatMap.Pipeable<OptionTypeLambda>['flatMap'] =
 		<A, B>(f: (a: A) => Option.Type<B>) => (self: Option.Type<A>): Option.Type<B> =>
 			Option.isNone(self) ? Option.None() : f(self.get())
 

--- a/src/option/option.ts
+++ b/src/option/option.ts
@@ -2,7 +2,7 @@ import type { Equals } from '../internal/equals.ts'
 import type * as F from '../internal/function.ts'
 import type { TypeLambda } from '../internal/hkt.ts'
 import type { Inspectable } from '../internal/inspectable.ts'
-import type { CovariantPipeable } from '../typeclass/covariant.ts'
+import { type CovariantPipeable, imap } from '../typeclass/covariant.ts'
 import type { FlatMapPipeable } from '../typeclass/flat-map.ts'
 import type {
 	FlatMap,
@@ -332,6 +332,10 @@ export abstract class Option<out A> implements Inspectable, Equals, FlatMap<Opti
 	public static map: CovariantPipeable<OptionTypeLambda>['map'] =
 		<A, B>(f: (a: A) => B) => (self: Option.Type<A>): Option.Type<B> =>
 			Option.isNone(self) ? Option.None() : Option.Some(f(self.get()))
+
+	public static imap: CovariantPipeable<OptionTypeLambda>['imap'] = imap<OptionTypeLambda>(
+		Option.map,
+	)
 
 	/**
 	 * Curried pattern matching for `Option` instances.

--- a/src/option/option.ts
+++ b/src/option/option.ts
@@ -9,6 +9,7 @@ import type {
 	// Covariant,
 	// Invariant
 } from '../typeclass/mod.ts'
+import type { OfPipeable } from '../typeclass/of.ts'
 
 function format(x: unknown): string {
 	return JSON.stringify(x, null, 2)
@@ -139,9 +140,11 @@ export abstract class Option<out A> implements Inspectable, Equals, FlatMap<Opti
 	 *
 	 * @param value - The value to wrap.
 	 * @returns An instance of {@linkcode Some(1)} containing the value.
+	 *
+	 * @alias Option.of
 	 */
 	public static Some<T>(value: T): Option.Type<T> {
-		return new Some(value)
+		return Option.of(value)
 	}
 
 	/**
@@ -367,6 +370,17 @@ export abstract class Option<out A> implements Inspectable, Equals, FlatMap<Opti
 	}): (self: Option.Type<A>) => B | C {
 		return Option.fold(cases.onNone, cases.onSome)
 	}
+
+	/**
+	 * lifts a value `A` to in the context of an `Option`
+	 *
+	 * @template A - The type of the value to lift
+	 * @param a - The value to lift
+	 * @returns An instance of {@linkcode Option.Type} containing the value of type `A`.
+	 *
+	 * @see Option.Some
+	 */
+	public static of: OfPipeable<OptionTypeLambda>['of'] = <A>(a: A): Option.Type<A> => new Some(a)
 
 	/**
 	 * Implements the {@linkcode Equals} interface, providing a way to compare two this Option instance with another unknown value that may be an Option or not.

--- a/src/option/option.ts
+++ b/src/option/option.ts
@@ -18,14 +18,14 @@ interface OptionTypeLambda extends TypeLambda {
  * The most idiomatic way to use an Option instance is to treat it as  monad and use `map`,`flatMap`,` filter`, or `foreach`:
  * These are useful methods that exist for both Some and None:
  * -[ ] `isDefined` : True if not empty
- * - {@linkcode Option#isEmpty} : True if empty
+ * - {@linkcode Option#isEmpty|isEmpty} : True if empty
  * -[ ] `nonEmpty`: True if not empty
  * -[ ] `orElse`: Evaluate and return alternate optional value if empty
- * -[ ] `getOrElse`: Evaluate and return alternate value if empty
- * - {@linkcode Option#get} : Return value, throw exception if empty
- * - {@linkcode Option#fold}: Apply function on optional value, return default if empty
+ * - {@linkcode Option#getOrElse|getOrElse}: Evaluate and return alternate value if empty
+ * - {@linkcode Option#get|get} : Return value, throw exception if empty
+ * - {@linkcode Option#fold|fold}: Apply function on optional value, return default if empty
  * -[ ] `map`: Apply a function on the optional value
- * -[ ] `flatMap`: Same as map but function must return an optional value
+ * - {@linkcode  Option#flatMap|flatMap }: Same as map but function must return an optional value
  * -[ ] `foreach`: Apply a procedure on option value
  * -[ ] `collect`: Apply partial pattern match on optional value
  * -[ ] `filter`: An optional value satisfies predicate

--- a/src/option/option.ts
+++ b/src/option/option.ts
@@ -65,8 +65,7 @@ interface OptionTypeLambda extends TypeLambda {
  * ```
  */
 export abstract class Option<out A>
-	implements Inspectable, Equals, FlatMapFluent<OptionTypeLambda>
-{
+	implements Inspectable, Equals, FlatMapFluent<OptionTypeLambda> {
 	/**
 	 * The discriminant property that identifies the type of the `Option` instance.
 	 */
@@ -144,24 +143,10 @@ export abstract class Option<out A>
 	 * Applies a function to the value of an Option and flattens the result, if the input is Some.
 	 * @returns A function that takes an Option and returns the result of applying `f` to this Option's value if the Option is nonempty. Otherwise, returns None.
 	 * @see  Option#flatMap
-	 *
-	 * @example
-	 * ```ts
-	 * import { assertStrictEquals } from 'jsr:@std/assert'
-	 * import { Option } from  './option.ts'
-	 * import { pipe } from '../internal/function.ts'
-	 *
-	 * const two = pipe(
-	 *  Option.Some(Option.Some(1)),
-	 *  Option.flatMap(a => a),
-	 *  Option.flatMap(a => Option.Some(a + 1)),
-	 *  Option.flatMap(a => a)
-	 * )
-	 * assertStrictEquals(two, 2)
-	 * ```
 	 */
-	public static flatMap: FlatMapPipable<OptionTypeLambda>['flatMap'] = f => self =>
-		self.isNone() ? Option.None() : f(self.get())
+	public static flatMap: FlatMapPipable<OptionTypeLambda>['flatMap'] =
+		<A, B>(f: (a: A) => Option.Type<B>) => (self: Option.Type<A>): Option.Type<B> =>
+			self.isNone() ? Option.None() : f(self.get())
 
 	/**
 	 * Returns a new function that takes an Option and returns the result of applying `f` to Option's value if the Option is nonempty. Otherwise, evaluates expression `ifEmpty`.
@@ -248,7 +233,7 @@ export abstract class Option<out A>
 		ifEmpty: F.Lazy<B>,
 		f: (a: A) => C,
 	): (self: Option.Type<A>) => B | C {
-		return self => (self.isEmpty() ? ifEmpty() : f(self.get()))
+		return (self) => (self.isEmpty() ? ifEmpty() : f(self.get()))
 	}
 
 	/**
@@ -437,8 +422,8 @@ export abstract class Option<out A>
 	): boolean {
 		return this.isSome()
 			? Option.isOption(that) &&
-					Option.isSome(that) &&
-					predicateStrategy(this.get(), that.get() as That)
+				Option.isSome(that) &&
+				predicateStrategy(this.get(), that.get() as That)
 			: Option.isOption(that) && Option.isNone(that)
 	}
 
@@ -641,8 +626,7 @@ export declare namespace Option {
 	 * const test2: Option.Value<typeof someOfNumber> = "42" // 💥ts error!
 	 * ```
 	 */
-	export type Value<T extends Option.Type<unknown>> = [T] extends [Option.Type<infer _A>]
-		? _A
+	export type Value<T extends Option.Type<unknown>> = [T] extends [Option.Type<infer _A>] ? _A
 		: never
 }
 

--- a/src/option/option.ts
+++ b/src/option/option.ts
@@ -1,19 +1,12 @@
 import type { Equals } from '../internal/equals.ts'
 import type * as F from '../internal/function.ts'
-import type { TypeLambda } from '../internal/hkt.ts'
+import type { TypeLambda as _TypeLambda } from '../internal/hkt.ts'
 
 import type { Inspectable } from '../internal/inspectable.ts'
 import { Covariant, type FlatMap, type Of } from '../typeclass/mod.ts'
 
 function format(x: unknown): string {
 	return JSON.stringify(x, null, 2)
-}
-
-/**
- * @internal
- */
-export interface OptionTypeLambda extends TypeLambda {
-	readonly type: Option.Type<this['Target']>
 }
 
 /**
@@ -72,8 +65,9 @@ export abstract class Option<out A>
 	implements
 		Inspectable,
 		Equals,
-		FlatMap.Fluent<OptionTypeLambda>,
-		Covariant.Fluent<OptionTypeLambda> {
+		FlatMap.Fluent<Option.TypeLambda>,
+		Covariant.Fluent<Option.TypeLambda>
+{
 	/**
 	 * The discriminant property that identifies the type of the `Option` instance.
 	 */
@@ -154,8 +148,9 @@ export abstract class Option<out A>
 	 * @returns A function that takes an Option and returns the result of applying `f` to this Option's value if the Option is nonempty. Otherwise, returns None.
 	 * @see  Option#flatMap
 	 */
-	public static flatMap: FlatMap.Pipeable<OptionTypeLambda>['flatMap'] =
-		<A, B>(f: (a: A) => Option.Type<B>) => (self: Option.Type<A>): Option.Type<B> =>
+	public static flatMap: FlatMap.Pipeable<Option.TypeLambda>['flatMap'] =
+		<A, B>(f: (a: A) => Option.Type<B>) =>
+		(self: Option.Type<A>): Option.Type<B> =>
 			Option.isNone(self) ? Option.None() : f(self.get())
 
 	/**
@@ -331,16 +326,16 @@ export abstract class Option<out A>
 	/**
 	 * @see Option#map
 	 */
-	public static map: Covariant.Pipeable<OptionTypeLambda>['map'] =
-		<A, B>(f: (a: A) => B) => (self: Option.Type<A>): Option.Type<B> =>
+	public static map: Covariant.Pipeable<Option.TypeLambda>['map'] =
+		<A, B>(f: (a: A) => B) =>
+		(self: Option.Type<A>): Option.Type<B> =>
 			Option.isNone(self) ? Option.None() : Option.Some(f(self.get()))
 
 	/**
 	 * @see Option#imap
 	 */
-	public static imap: Covariant.Pipeable<OptionTypeLambda>['imap'] = Covariant.imap<
-		OptionTypeLambda
-	>(Option.map)
+	public static imap: Covariant.Pipeable<Option.TypeLambda>['imap'] =
+		Covariant.imap<Option.TypeLambda>(Option.map)
 
 	/**
 	 * Curried pattern matching for `Option` instances.
@@ -392,7 +387,7 @@ export abstract class Option<out A>
 	 *
 	 * @see Option.Some
 	 */
-	public static of: Of.Pipeable<OptionTypeLambda>['of'] = <A>(a: A): Option.Type<A> => new Some(a)
+	public static of: Of.Pipeable<Option.TypeLambda>['of'] = <A>(a: A): Option.Type<A> => new Some(a)
 
 	/**
 	 * Implements the {@linkcode Equals} interface, providing a way to compare two this Option instance with another unknown value that may be an Option or not.
@@ -457,8 +452,8 @@ export abstract class Option<out A>
 	): boolean {
 		return this.isSome()
 			? Option.isOption(that) &&
-				Option.isSome(that) &&
-				predicateStrategy(this.get(), that.get() as That)
+					Option.isSome(that) &&
+					predicateStrategy(this.get(), that.get() as That)
 			: Option.isOption(that) && Option.isNone(that)
 	}
 
@@ -696,8 +691,16 @@ export declare namespace Option {
 	 * const test2: Option.Value<typeof someOfNumber> = "42" // 💥ts error!
 	 * ```
 	 */
-	export type Value<T extends Option.Type<unknown>> = [T] extends [Option.Type<infer _A>] ? _A
+	export type Value<T extends Option.Type<unknown>> = [T] extends [Option.Type<infer _A>]
+		? _A
 		: never
+
+	/**
+	 * @internal
+	 */
+	export interface TypeLambda extends _TypeLambda {
+		readonly type: Type<this['Target']>
+	}
 }
 
 /**

--- a/src/option/option.ts
+++ b/src/option/option.ts
@@ -1,13 +1,9 @@
 import type { Equals } from '../internal/equals.ts'
 import type * as F from '../internal/function.ts'
 import type { TypeLambda } from '../internal/hkt.ts'
+
 import type { Inspectable } from '../internal/inspectable.ts'
-import { type CovariantPipeable, imap } from '../typeclass/covariant.ts'
-import type {
-	FlatMap,
-	// Covariant,
-	// Invariant
-} from '../typeclass/mod.ts'
+import { Covariant, type FlatMap } from '../typeclass/mod.ts'
 import type { OfPipeable } from '../typeclass/of.ts'
 
 function format(x: unknown): string {
@@ -329,13 +325,13 @@ export abstract class Option<out A>
 		return self instanceof Some
 	}
 
-	public static map: CovariantPipeable<OptionTypeLambda>['map'] =
+	public static map: Covariant.Pipeable<OptionTypeLambda>['map'] =
 		<A, B>(f: (a: A) => B) => (self: Option.Type<A>): Option.Type<B> =>
 			Option.isNone(self) ? Option.None() : Option.Some(f(self.get()))
 
-	public static imap: CovariantPipeable<OptionTypeLambda>['imap'] = imap<OptionTypeLambda>(
-		Option.map,
-	)
+	public static imap: Covariant.Pipeable<OptionTypeLambda>['imap'] = Covariant.imap<
+		OptionTypeLambda
+	>(Option.map)
 
 	/**
 	 * Curried pattern matching for `Option` instances.
@@ -622,7 +618,6 @@ export abstract class Option<out A>
 /**
  * The type-level namespace for Option
  * @namespace Option
- * @since 0.0.1
  */
 export declare namespace Option {
 	/**

--- a/src/option/option.ts
+++ b/src/option/option.ts
@@ -114,6 +114,7 @@ export abstract class Option<out A> implements Inspectable, Equals, FlatMap<Opti
 	 * @see {Option.flatMap}
 	 * @see map
 	 * @see foreach
+	 * @implements {FlatMap}
 	 */
 	public flatMap<A, B>(this: Option.Type<A>, f: (a: A) => Option.Type<B>): Option.Type<B> {
 		return Option.flatMap(f)(this)

--- a/src/option/option.ts
+++ b/src/option/option.ts
@@ -3,8 +3,7 @@ import type * as F from '../internal/function.ts'
 import type { TypeLambda } from '../internal/hkt.ts'
 
 import type { Inspectable } from '../internal/inspectable.ts'
-import { Covariant, type FlatMap } from '../typeclass/mod.ts'
-import type { OfPipeable } from '../typeclass/of.ts'
+import { Covariant, type FlatMap, type Of } from '../typeclass/mod.ts'
 
 function format(x: unknown): string {
 	return JSON.stringify(x, null, 2)
@@ -383,7 +382,7 @@ export abstract class Option<out A>
 	 *
 	 * @see Option.Some
 	 */
-	public static of: OfPipeable<OptionTypeLambda>['of'] = <A>(a: A): Option.Type<A> => new Some(a)
+	public static of: Of.Pipeable<OptionTypeLambda>['of'] = <A>(a: A): Option.Type<A> => new Some(a)
 
 	/**
 	 * Implements the {@linkcode Equals} interface, providing a way to compare two this Option instance with another unknown value that may be an Option or not.

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -1,0 +1,13 @@
+import { assertEquals, assertStrictEquals } from 'jsr:@std/assert'
+import type { Option } from '../option/option.ts'
+
+// deno-lint-ignore no-namespace
+export namespace Util {
+	export const deepStrictEqual = <A>(actual: A, expected: A) => {
+		assertEquals(actual, expected)
+	}
+
+	export const optionEqual = <A>(actual: Option.Type<A>, expected: Option.Type<A>) => {
+		assertStrictEquals(actual.equals(expected), true)
+	}
+}

--- a/src/typeclass/covariant.test.ts
+++ b/src/typeclass/covariant.test.ts
@@ -1,13 +1,13 @@
 import { describe, it } from 'jsr:@std/testing/bdd'
 import { pipe } from '../internal/function.ts'
-import { Option, type OptionTypeLambda } from '../option/option.ts'
+import { Option } from '../option/option.ts'
 
 import { Util } from '../test/utils.ts'
 import { Covariant } from './covariant.ts'
 
 describe('Covariant', () => {
 	it('imap', () => {
-		const f = Covariant.imap<OptionTypeLambda>(Option.map)(
+		const f = Covariant.imap<Option.TypeLambda>(Option.map)(
 			(s: string) => [s],
 			([s]) => s,
 		)

--- a/src/typeclass/covariant.test.ts
+++ b/src/typeclass/covariant.test.ts
@@ -1,0 +1,17 @@
+import { describe, it } from 'jsr:@std/testing/bdd'
+import { pipe } from '../internal/function.ts'
+import { Option, type OptionTypeLambda } from '../option/option.ts'
+
+import { Util } from '../test/utils.ts'
+import * as _ from './covariant.ts'
+
+describe('Covariant', () => {
+	it('imap', () => {
+		const f = _.imap<OptionTypeLambda>(Option.map)(
+			(s: string) => [s],
+			([s]) => s,
+		)
+		Util.deepStrictEqual(pipe(Option.None<string>(), f), Option.None())
+		Util.deepStrictEqual(pipe(Option.of('a'), f), Option.of(['a']))
+	})
+})

--- a/src/typeclass/covariant.test.ts
+++ b/src/typeclass/covariant.test.ts
@@ -3,11 +3,11 @@ import { pipe } from '../internal/function.ts'
 import { Option, type OptionTypeLambda } from '../option/option.ts'
 
 import { Util } from '../test/utils.ts'
-import * as _ from './covariant.ts'
+import { Covariant } from './covariant.ts'
 
 describe('Covariant', () => {
 	it('imap', () => {
-		const f = _.imap<OptionTypeLambda>(Option.map)(
+		const f = Covariant.imap<OptionTypeLambda>(Option.map)(
 			(s: string) => [s],
 			([s]) => s,
 		)

--- a/src/typeclass/covariant.ts
+++ b/src/typeclass/covariant.ts
@@ -1,5 +1,5 @@
 import type { Kind, TypeLambda } from '../internal/hkt.ts'
-import type { InvariantFluent, InvariantPipeable } from './invariant.ts'
+import type { Invariant } from './invariant.ts'
 
 /**
  * Must obey the laws defined in {@link cats.laws.FunctorLaws}.
@@ -13,11 +13,11 @@ import type { InvariantFluent, InvariantPipeable } from './invariant.ts'
  * - Composition: Mapping with `f` and then again with `g` is the same as mapping once with the composition of `f` and `g`
  * `fa.map(f).map(g) = fa.map(f.andThen(g))`
  */
-export interface CovariantFluent<F extends TypeLambda> extends InvariantFluent<F> {
+export interface CovariantFluent<F extends TypeLambda> extends Invariant.Fluent<F> {
 	map<R, O, E, A, B>(this: Kind<F, R, O, E, A>, f: (a: A) => B): Kind<F, R, O, E, B>
 }
 
-export interface CovariantPipeable<F extends TypeLambda> extends InvariantPipeable<F> {
+export interface CovariantPipeable<F extends TypeLambda> extends Invariant.Pipeable<F> {
 	new <A, In, Out2, Out1>(): Kind<F, In, Out2, Out1, A>
 
 	// static curried map
@@ -28,5 +28,5 @@ export interface CovariantPipeable<F extends TypeLambda> extends InvariantPipeab
 
 export const imap = <F extends TypeLambda>(
 	map: <A, B>(f: (a: A) => B) => <R, O, E>(self: Kind<F, R, O, E, A>) => Kind<F, R, O, E, B>,
-): InvariantPipeable<F>['imap'] =>
+): Invariant.Pipeable<F>['imap'] =>
 (self, _to) => map(self)

--- a/src/typeclass/covariant.ts
+++ b/src/typeclass/covariant.ts
@@ -1,6 +1,22 @@
 import type { Kind, TypeLambda } from '../internal/hkt.ts'
 import type { InvariantFluent, InvariantPipeable } from './invariant.ts'
 
+/**
+ * Must obey the laws defined in {@link cats.laws.FunctorLaws}.
+ *
+ * @remarks
+ * Laws that must be obeyed by any `Functor`.
+ *
+ * - Identity: Mapping with the identity function is a no-op
+ * `fa.map(a => a) <-> fa`
+ *
+ * - Composition: Mapping with `f` and then again with `g` is the same as mapping once with the composition of `f` and `g`
+ * `fa.map(f).map(g) = fa.map(f.andThen(g))`
+ */
+export interface CovariantFluent<F extends TypeLambda> extends InvariantFluent<F> {
+	map<R, O, E, A, B>(this: Kind<F, R, O, E, A>, f: (a: A) => B): Kind<F, R, O, E, B>
+}
+
 export interface CovariantPipeable<F extends TypeLambda> extends InvariantPipeable<F> {
 	new <A, In, Out2, Out1>(): Kind<F, In, Out2, Out1, A>
 
@@ -8,8 +24,4 @@ export interface CovariantPipeable<F extends TypeLambda> extends InvariantPipeab
 	readonly map: <A, B>(
 		f: (a: A) => B,
 	) => <R, O, E>(self: Kind<F, R, O, E, A>) => Kind<F, R, O, E, B>
-}
-
-export interface CovariantFluent<F extends TypeLambda> extends InvariantFluent<F> {
-	map<R, O, E, A, B>(this: Kind<F, R, O, E, A>, f: (a: A) => B): Kind<F, R, O, E, B>
 }

--- a/src/typeclass/covariant.ts
+++ b/src/typeclass/covariant.ts
@@ -2,7 +2,8 @@ import type { Kind, TypeLambda } from '../internal/hkt.ts'
 import type { Invariant } from './invariant.ts'
 
 /**
- * Must obey the laws defined in {@link cats.laws.FunctorLaws}.
+ * Covariant is a type class that abstracts over type constructors that can be mapped over.
+ * Examples of such type constructors in Scala are `List`, `Option`, and `Future`.
  *
  * @remarks
  * Laws that must be obeyed by any `Functor`.
@@ -13,20 +14,19 @@ import type { Invariant } from './invariant.ts'
  * - Composition: Mapping with `f` and then again with `g` is the same as mapping once with the composition of `f` and `g`
  * `fa.map(f).map(g) = fa.map(f.andThen(g))`
  */
-export interface CovariantFluent<F extends TypeLambda> extends Invariant.Fluent<F> {
-	map<R, O, E, A, B>(this: Kind<F, R, O, E, A>, f: (a: A) => B): Kind<F, R, O, E, B>
+export declare namespace Covariant {
+	export interface Fluent<F extends TypeLambda> extends Invariant.Fluent<F> {
+		map<R, O, E, A, B>(this: Kind<F, R, O, E, A>, f: (a: A) => B): Kind<F, R, O, E, B>
+	}
+
+	export interface Pipeable<F extends TypeLambda> extends Invariant.Pipeable<F> {
+		map<A, B>(f: (a: A) => B): <R, O, E>(self: Kind<F, R, O, E, A>) => Kind<F, R, O, E, B>
+	}
 }
 
-export interface CovariantPipeable<F extends TypeLambda> extends Invariant.Pipeable<F> {
-	new <A, In, Out2, Out1>(): Kind<F, In, Out2, Out1, A>
-
-	// static curried map
-	readonly map: <A, B>(
-		f: (a: A) => B,
-	) => <R, O, E>(self: Kind<F, R, O, E, A>) => Kind<F, R, O, E, B>
-}
-
-export const imap = <F extends TypeLambda>(
-	map: <A, B>(f: (a: A) => B) => <R, O, E>(self: Kind<F, R, O, E, A>) => Kind<F, R, O, E, B>,
-): Invariant.Pipeable<F>['imap'] =>
-(self, _to) => map(self)
+export const Covariant = {
+	imap: <F extends TypeLambda>(
+		map: <A, B>(f: (a: A) => B) => <R, O, E>(self: Kind<F, R, O, E, A>) => Kind<F, R, O, E, B>,
+	): Invariant.Pipeable<F>['imap'] =>
+	(self, _to) => map(self),
+} as const

--- a/src/typeclass/covariant.ts
+++ b/src/typeclass/covariant.ts
@@ -25,3 +25,8 @@ export interface CovariantPipeable<F extends TypeLambda> extends InvariantPipeab
 		f: (a: A) => B,
 	) => <R, O, E>(self: Kind<F, R, O, E, A>) => Kind<F, R, O, E, B>
 }
+
+export const imap = <F extends TypeLambda>(
+	map: <A, B>(f: (a: A) => B) => <R, O, E>(self: Kind<F, R, O, E, A>) => Kind<F, R, O, E, B>,
+): InvariantPipeable<F>['imap'] =>
+(self, _to) => map(self)

--- a/src/typeclass/covariant.ts
+++ b/src/typeclass/covariant.ts
@@ -1,0 +1,15 @@
+import type { Kind, TypeLambda } from '../internal/hkt.ts'
+import type { InvariantFluent, InvariantPipeable } from './invariant.ts'
+
+export interface CovariantPipeable<F extends TypeLambda> extends InvariantPipeable<F> {
+	new <A, In, Out2, Out1>(): Kind<F, In, Out2, Out1, A>
+
+	// static curried map
+	readonly map: <A, B>(
+		f: (a: A) => B,
+	) => <R, O, E>(self: Kind<F, R, O, E, A>) => Kind<F, R, O, E, B>
+}
+
+export interface CovariantFluent<F extends TypeLambda> extends InvariantFluent<F> {
+	map<R, O, E, A, B>(this: Kind<F, R, O, E, A>, f: (a: A) => B): Kind<F, R, O, E, B>
+}

--- a/src/typeclass/flat-map.ts
+++ b/src/typeclass/flat-map.ts
@@ -1,7 +1,7 @@
 import type { Kind, TypeClass, TypeLambda } from '../internal/hkt.ts'
 
 /**
- * {@linkcode FlatMap} type class gives us {@linkcode FlatMap.flatMap|flatMap}, which allows us to have a `value` in a context `(F[A])` and then feed that into a function that takes a normal value and returns a value in a context `(A => F[B])`.
+ * {@linkcode FlatMapFluent} type class gives us {@linkcode FlatMap.flatMap|flatMap}, which allows us to have a `value` in a context `(F[A])` and then feed that into a function that takes a normal value and returns a value in a context `(A => F[B])`.
  *
  * One motivation for separating this out from Monad is that there are
  * situations where we can implement `flatMap` but not `pure`.
@@ -15,9 +15,19 @@ import type { Kind, TypeClass, TypeLambda } from '../internal/hkt.ts'
  *     fa.flatMap(f).flatMap(g) <-> fa.flatMap(a => f(a).flatMap(g))
  * ```
  */
-export interface FlatMap<F extends TypeLambda> extends TypeClass<F> {
+export interface FlatMapFluent<F extends TypeLambda> extends TypeClass<F> {
 	flatMap<R1, O1, E1, A, R2, O2, E2, B>(
 		this: Kind<F, R1, O1, E1, A>,
 		f: (a: A) => Kind<F, R2, O2, E2, B>,
 	): Kind<F, R1 & R2, O1 | O2, E1 | E2, B>
 }
+
+export interface FlatMapPipable<F extends TypeLambda> extends TypeClass<F> {
+	new <A, In, Out2, Out1>(): Kind<F, In, Out2, Out1, A>
+
+	readonly flatMap: <A, R2, O2, E2, B>(
+		f: (a: A) => Kind<F, R2, O2, E2, B>,
+	) => <R1, O1, E1>(self: Kind<F, R1, O1, E1, A>) => Kind<F, R1 & R2, O1 | O2, E1 | E2, B>
+}
+
+export type FlatMap<F extends TypeLambda> = FlatMapFluent<F> & FlatMapPipable<F>

--- a/src/typeclass/flat-map.ts
+++ b/src/typeclass/flat-map.ts
@@ -22,12 +22,10 @@ export interface FlatMapFluent<F extends TypeLambda> extends TypeClass<F> {
 	): Kind<F, R1 & R2, O1 | O2, E1 | E2, B>
 }
 
-export interface FlatMapPipable<F extends TypeLambda> extends TypeClass<F> {
+export interface FlatMapPipeable<F extends TypeLambda> extends TypeClass<F> {
 	new <A, In, Out2, Out1>(): Kind<F, In, Out2, Out1, A>
 
 	readonly flatMap: <A, R2, O2, E2, B>(
 		f: (a: A) => Kind<F, R2, O2, E2, B>,
 	) => <R1, O1, E1>(self: Kind<F, R1, O1, E1, A>) => Kind<F, R1 & R2, O1 | O2, E1 | E2, B>
 }
-
-export type FlatMap<F extends TypeLambda> = FlatMapFluent<F> & FlatMapPipable<F>

--- a/src/typeclass/flat-map.ts
+++ b/src/typeclass/flat-map.ts
@@ -1,0 +1,23 @@
+import type { Kind, TypeClass, TypeLambda } from '../internal/hkt.ts'
+
+/**
+ * {@linkcode FlatMap} type class gives us {@linkcode FlatMap.flatMap|flatMap}, which allows us to have a `value` in a context `(F[A])` and then feed that into a function that takes a normal value and returns a value in a context `(A => F[B])`.
+ *
+ * One motivation for separating this out from Monad is that there are
+ * situations where we can implement `flatMap` but not `pure`.
+ *
+ * @see See [[https://github.com/typelevel/cats/issues/3]] for some discussion.
+ *
+ * Must obey the laws defined in cats.laws.FlatMapLaws.
+ * - Associativity:
+ * ```scala
+ * def flatMapAssociativity[A, B, C](fa: F[A], f: A => F[B], g: B => F[C]): IsEq[F[C]] =
+ *     fa.flatMap(f).flatMap(g) <-> fa.flatMap(a => f(a).flatMap(g))
+ * ```
+ */
+export interface FlatMap<F extends TypeLambda> extends TypeClass<F> {
+	flatMap<R1, O1, E1, A, R2, O2, E2, B>(
+		this: Kind<F, R1, O1, E1, A>,
+		f: (a: A) => Kind<F, R2, O2, E2, B>,
+	): Kind<F, R1 & R2, O1 | O2, E1 | E2, B>
+}

--- a/src/typeclass/flat-map.ts
+++ b/src/typeclass/flat-map.ts
@@ -1,7 +1,7 @@
 import type { Kind, TypeClass, TypeLambda } from '../internal/hkt.ts'
 
 /**
- * {@linkcode FlatMapFluent} type class gives us {@linkcode FlatMap.flatMap|flatMap}, which allows us to have a `value` in a context `(F[A])` and then feed that into a function that takes a normal value and returns a value in a context `(A => F[B])`.
+ * {@linkcode FlatMap.Fluent} type class gives us {@linkcode FlatMap.flatMap|flatMap}, which allows us to have a `value` in a context `(F[A])` and then feed that into a function that takes a normal value and returns a value in a context `(A => F[B])`.
  *
  * One motivation for separating this out from Monad is that there are
  * situations where we can implement `flatMap` but not `pure`.
@@ -15,17 +15,17 @@ import type { Kind, TypeClass, TypeLambda } from '../internal/hkt.ts'
  *     fa.flatMap(f).flatMap(g) <-> fa.flatMap(a => f(a).flatMap(g))
  * ```
  */
-export interface FlatMapFluent<F extends TypeLambda> extends TypeClass<F> {
-	flatMap<R1, O1, E1, A, R2, O2, E2, B>(
-		this: Kind<F, R1, O1, E1, A>,
-		f: (a: A) => Kind<F, R2, O2, E2, B>,
-	): Kind<F, R1 & R2, O1 | O2, E1 | E2, B>
-}
+export declare namespace FlatMap {
+	export interface Fluent<F extends TypeLambda> extends TypeClass<F> {
+		flatMap<R1, O1, E1, A, R2, O2, E2, B>(
+			this: Kind<F, R1, O1, E1, A>,
+			f: (a: A) => Kind<F, R2, O2, E2, B>,
+		): Kind<F, R1 & R2, O1 | O2, E1 | E2, B>
+	}
 
-export interface FlatMapPipeable<F extends TypeLambda> extends TypeClass<F> {
-	new <A, In, Out2, Out1>(): Kind<F, In, Out2, Out1, A>
-
-	readonly flatMap: <A, R2, O2, E2, B>(
-		f: (a: A) => Kind<F, R2, O2, E2, B>,
-	) => <R1, O1, E1>(self: Kind<F, R1, O1, E1, A>) => Kind<F, R1 & R2, O1 | O2, E1 | E2, B>
+	export interface Pipeable<F extends TypeLambda> extends TypeClass<F> {
+		readonly flatMap: <A, R2, O2, E2, B>(
+			f: (a: A) => Kind<F, R2, O2, E2, B>,
+		) => <R1, O1, E1>(self: Kind<F, R1, O1, E1, A>) => Kind<F, R1 & R2, O1 | O2, E1 | E2, B>
+	}
 }

--- a/src/typeclass/invariant.ts
+++ b/src/typeclass/invariant.ts
@@ -1,5 +1,18 @@
 import type { Kind, TypeClass, TypeLambda } from '../internal/hkt.ts'
 
+/**
+ * Must obey the laws defined in {@link cats.laws.InvariantLaws}.
+ * - identity:
+ * ```scala
+ * def invariantIdentity[A](fa: F[A]): IsEq[F[A]] =
+ *     fa.imap(identity[A])(identity[A]) <-> fa
+ * ```
+ * - composition:
+ * ```scala
+ *  def invariantComposition[A, B, C](fa: F[A], f1: A => B, f2: B => A, g1: B => C, g2: C => B): IsEq[F[C]] =
+ *     fa.imap(f1)(f2).imap(g1)(g2) <-> fa.imap(g1.compose(f1))(f2.compose(g2))
+ * ```
+ */
 export interface InvariantFluent<F extends TypeLambda> extends TypeClass<F> {
 	imap<R, O, E, A, B>(
 		this: Kind<F, R, O, E, A>,
@@ -9,10 +22,11 @@ export interface InvariantFluent<F extends TypeLambda> extends TypeClass<F> {
 }
 
 export interface InvariantPipeable<F extends TypeLambda> extends TypeClass<F> {
-	imap<A, B>(
+	new <A, In, Out2, Out1>(): Kind<F, In, Out2, Out1, A>
+
+	// static curried Imap
+	readonly imap: <A, B>(
 		to: (a: A) => B,
 		from: (b: B) => A,
-	): <R, O, E>(self: Kind<F, R, O, E, A>) => Kind<F, R, O, E, B>
+	) => <R, O, E>(self: Kind<F, R, O, E, A>) => Kind<F, R, O, E, B>
 }
-
-export type Invariant<F extends TypeLambda> = InvariantFluent<F> & InvariantPipeable<F>

--- a/src/typeclass/invariant.ts
+++ b/src/typeclass/invariant.ts
@@ -1,0 +1,18 @@
+import type { Kind, TypeClass, TypeLambda } from '../internal/hkt.ts'
+
+export interface InvariantFluent<F extends TypeLambda> extends TypeClass<F> {
+	imap<R, O, E, A, B>(
+		this: Kind<F, R, O, E, A>,
+		to: (a: A) => B,
+		from: (b: B) => A,
+	): Kind<F, R, O, E, B>
+}
+
+export interface InvariantPipeable<F extends TypeLambda> extends TypeClass<F> {
+	imap<A, B>(
+		to: (a: A) => B,
+		from: (b: B) => A,
+	): <R, O, E>(self: Kind<F, R, O, E, A>) => Kind<F, R, O, E, B>
+}
+
+export type Invariant<F extends TypeLambda> = InvariantFluent<F> & InvariantPipeable<F>

--- a/src/typeclass/invariant.ts
+++ b/src/typeclass/invariant.ts
@@ -13,20 +13,19 @@ import type { Kind, TypeClass, TypeLambda } from '../internal/hkt.ts'
  *     fa.imap(f1)(f2).imap(g1)(g2) <-> fa.imap(g1.compose(f1))(f2.compose(g2))
  * ```
  */
-export interface InvariantFluent<F extends TypeLambda> extends TypeClass<F> {
-	imap<R, O, E, A, B>(
-		this: Kind<F, R, O, E, A>,
-		to: (a: A) => B,
-		from: (b: B) => A,
-	): Kind<F, R, O, E, B>
-}
+export declare namespace Invariant {
+	export interface Fluent<F extends TypeLambda> extends TypeClass<F> {
+		imap<R, O, E, A, B>(
+			this: Kind<F, R, O, E, A>,
+			to: (a: A) => B,
+			from: (b: B) => A,
+		): Kind<F, R, O, E, B>
+	}
 
-export interface InvariantPipeable<F extends TypeLambda> extends TypeClass<F> {
-	new <A, In, Out2, Out1>(): Kind<F, In, Out2, Out1, A>
-
-	// static curried Imap
-	readonly imap: <A, B>(
-		to: (a: A) => B,
-		from: (b: B) => A,
-	) => <R, O, E>(self: Kind<F, R, O, E, A>) => Kind<F, R, O, E, B>
+	export interface Pipeable<F extends TypeLambda> extends TypeClass<F> {
+		imap<A, B>(
+			to: (a: A) => B,
+			from: (b: B) => A,
+		): <R, O, E>(self: Kind<F, R, O, E, A>) => Kind<F, R, O, E, B>
+	}
 }

--- a/src/typeclass/mod.ts
+++ b/src/typeclass/mod.ts
@@ -1,0 +1,1 @@
+export type { FlatMap } from './flat-map.ts'

--- a/src/typeclass/mod.ts
+++ b/src/typeclass/mod.ts
@@ -1,2 +1,2 @@
-export type { FlatMap } from './flat-map.ts'
-export type { Invariant } from './invariant.ts'
+export type { FlatMapFluent as FlatMap } from './flat-map.ts'
+export type { InvariantFluent as Invariant } from './invariant.ts'

--- a/src/typeclass/mod.ts
+++ b/src/typeclass/mod.ts
@@ -1,3 +1,4 @@
 export type { FlatMap } from './flat-map.ts'
 export type { Invariant } from './invariant.ts'
 export { Covariant } from './covariant.ts'
+export type { Of } from './of.ts'

--- a/src/typeclass/mod.ts
+++ b/src/typeclass/mod.ts
@@ -1,1 +1,2 @@
 export type { FlatMap } from './flat-map.ts'
+export type { Invariant } from './invariant.ts'

--- a/src/typeclass/mod.ts
+++ b/src/typeclass/mod.ts
@@ -1,3 +1,3 @@
 export type { FlatMap } from './flat-map.ts'
-export type { InvariantFluent as Invariant } from './invariant.ts'
+export type { Invariant } from './invariant.ts'
 export type { CovariantFluent as Covariant } from './covariant.ts'

--- a/src/typeclass/mod.ts
+++ b/src/typeclass/mod.ts
@@ -1,2 +1,3 @@
 export type { FlatMapFluent as FlatMap } from './flat-map.ts'
 export type { InvariantFluent as Invariant } from './invariant.ts'
+export type { CovariantFluent as Covariant } from './covariant.ts'

--- a/src/typeclass/mod.ts
+++ b/src/typeclass/mod.ts
@@ -1,3 +1,3 @@
 export type { FlatMap } from './flat-map.ts'
 export type { Invariant } from './invariant.ts'
-export type { CovariantFluent as Covariant } from './covariant.ts'
+export { Covariant } from './covariant.ts'

--- a/src/typeclass/mod.ts
+++ b/src/typeclass/mod.ts
@@ -1,3 +1,3 @@
-export type { FlatMapFluent as FlatMap } from './flat-map.ts'
+export type { FlatMap } from './flat-map.ts'
 export type { InvariantFluent as Invariant } from './invariant.ts'
 export type { CovariantFluent as Covariant } from './covariant.ts'

--- a/src/typeclass/of.ts
+++ b/src/typeclass/of.ts
@@ -1,0 +1,7 @@
+import type { Kind, TypeClass, TypeLambda } from '../internal/hkt.ts'
+
+export interface OfPipeable<F extends TypeLambda> extends TypeClass<F> {
+	new <A, In, Out2, Out1>(): Kind<F, In, Out2, Out1, A>
+
+	readonly of: <A>(a: A) => Kind<F, unknown, never, never, A>
+}

--- a/src/typeclass/of.ts
+++ b/src/typeclass/of.ts
@@ -1,7 +1,7 @@
 import type { Kind, TypeClass, TypeLambda } from '../internal/hkt.ts'
 
-export interface OfPipeable<F extends TypeLambda> extends TypeClass<F> {
-	new <A, In, Out2, Out1>(): Kind<F, In, Out2, Out1, A>
-
-	readonly of: <A>(a: A) => Kind<F, unknown, never, never, A>
+export declare namespace Of {
+	export interface Pipeable<F extends TypeLambda> extends TypeClass<F> {
+		of<A>(a: A): Kind<F, unknown, never, never, A>
+	}
 }


### PR DESCRIPTION
This Pull Request introduces a series of significant changes designed to enrich the codebase's use of Higher-Kinded Types and Type Classes. It also embodies our first draft for enabling the Option data type to leverage the Monad type class. The following highlights capture the essence of the alterations:

1. The inception of interfaces TypeClass and TypeLambda set the stage for managing higher-kinded types more efficiently.
2. The flatMap function became a part of the Option class, enhancing its functional capabilities.
3. Subsequent tests ensured the flatMap function performed as intended, demonstrating practical use of the Monad concept.
4. The FlatMap interface's split into FlatMapFluent and FlatMapPipeable refined the structure of the code.
5. Readability and simplicity took the spotlight during several refactorings, with optimization and clarification being the primary objectives.
6. The Covariant interfaces arrived, enriching the base by allowing map operations on all data types.
7. Closing the loop of primary changes, TypeLambda replaced instances of redundant internal interfaces within the Option and Covariant modules.

This series of changes provides better type safety and lays the foundation for mapping and transformation options (with Covariant) and chaining computations (with FlatMap and Monad). The transformation it initiates strikes a harmonious balance between correctness, expressivity, and readability while staying true to the core principles of functional programming.