### PR TITLE
Enhancements to the 'Option' Class and Documentation

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,6 +1,6 @@
 {
 	"name": "@suddenly-giovanni/std",
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"lock": true,
 	"exports": {
 		"./predicate": "./src/predicate/mod.ts",

--- a/src/internal/hkt.ts
+++ b/src/internal/hkt.ts
@@ -1,7 +1,29 @@
+/**
+ * This module provide the tools to implement Higher Kinded Types (HKT) in TypeScript.
+ *
+ * Disclaimer: it is a "copy pasta" 🍝 from the [effect library](https://github.com/Effect-TS/effect/blob/184fed83ac36cba05a75a5a8013f740f9f696e3b/packages/effect/src/HKT.ts); all credits goes to the authors of the library.
+ *
+ * @internal
+ * @module
+ */
+
 import type { Types } from './types.ts'
 
+/**
+ * Represents a URI (Uniform Resource Identifier).
+ *
+ * @typedef {symbol} URI
+ * @description A URI is a unique symbol used to identify a resource on the web.
+ */
 export declare const URI: unique symbol
 
+/**
+ * Represents a class that is parameterized by a type `F`.
+ * The `TypeClass` interface enforces that the implementing class must have an optional property `[URI]`
+ * which is of type `F` to improve inference.
+ *
+ * @template F - The type parameter.
+ */
 export interface TypeClass<F extends TypeLambda> {
 	/**
 	 * To improve inference it is necessary to mention the F parameter inside it otherwise it will be lost, we can do so by adding an optional property

--- a/src/option/option.test.ts
+++ b/src/option/option.test.ts
@@ -30,6 +30,12 @@ describe('Option', () => {
 			const some = Option.Some(1)
 			expect(some._tag).toBe('Some')
 			expect(some.get()).toBe(1)
+
+			// @ts-expect-error - should not allow null or undefined
+			expectTypeOf(Option.Some(null)).not.toEqualTypeOf<Option.Type<null>>()
+
+			// @ts-expect-error - should not allow null or undefined
+			expectTypeOf(Option.Some(undefined)).not.toEqualTypeOf<Option.Type<undefined>>()
 		})
 
 		describe('None', () => {

--- a/src/option/option.test.ts
+++ b/src/option/option.test.ts
@@ -289,17 +289,17 @@ describe('Option', () => {
 		const g = () => Option.None<string>()
 
 		test('static', () => {
-			Util.deepStrictEqual(pipe(Option.Some(1), Option.flatMap(f)), Option.Some(2))
-			Util.deepStrictEqual(pipe(Option.None(), Option.flatMap(f)), Option.None())
-			Util.deepStrictEqual(pipe(Option.Some(1), Option.flatMap(g)), Option.None())
-			Util.deepStrictEqual(pipe(Option.None(), Option.flatMap(g)), Option.None())
+			Util.optionEqual(pipe(Option.Some(1), Option.flatMap(f)), Option.Some(2))
+			Util.optionEqual(pipe(Option.None(), Option.flatMap(f)), Option.None())
+			Util.optionEqual(pipe(Option.Some(1), Option.flatMap(g)), Option.None())
+			Util.optionEqual(pipe(Option.None(), Option.flatMap(g)), Option.None())
 		})
 
 		test('instance', () => {
-			Util.deepStrictEqual(Option.Some(1).flatMap(f), Option.Some(2))
-			Util.deepStrictEqual(Option.None().flatMap(f), Option.None())
-			Util.deepStrictEqual(Option.Some(1).flatMap(g), Option.None())
-			Util.deepStrictEqual(Option.None().flatMap(g), Option.None())
+			Util.optionEqual(Option.Some(1).flatMap(f), Option.Some(2))
+			Util.optionEqual(Option.None().flatMap(f), Option.None())
+			Util.optionEqual(Option.Some(1).flatMap(g), Option.None())
+			Util.optionEqual(Option.None().flatMap(g), Option.None())
 		})
 
 		test('associativity law', () => {
@@ -345,12 +345,12 @@ describe('Option', () => {
 		})
 
 		describe('isNone', () => {
-			test('on Option static method ', () => {
+			test('static', () => {
 				expect(pipe(Option.None(), Option.isNone)).toBe(true)
 				expect(pipe(Option.Some(1), Option.isNone)).toBe(false)
 			})
 
-			test('on Option instances: Some and None ', () => {
+			test('instance', () => {
 				expect(Option.fromNullable(42).isNone()).toBe(false)
 				expect(Option.fromNullable(undefined).isNone()).toBe(true)
 			})

--- a/src/option/option.test.ts
+++ b/src/option/option.test.ts
@@ -52,17 +52,21 @@ describe('Option', () => {
 		})
 
 		test('fromNullable', () => {
-			expect(Option.fromNullable(2).equals(Option.Some(2))).toBe(true)
-			expectTypeOf(Option.fromNullable(2)).toEqualTypeOf<Option.Type<number>>()
+			expect(Option.fromNullable<null | number>(2).equals(Option.Some(2))).toBe(true)
+			expectTypeOf(Option.fromNullable<null | number>(2)).toEqualTypeOf<Option.Type<number>>()
 
 			expect(Option.fromNullable(0).equals(Option.Some(0))).toBe(true)
 			expectTypeOf(Option.fromNullable(0)).toEqualTypeOf<Option.Type<number>>()
 
 			expect(Option.fromNullable('').equals(Option.Some(''))).toBe(true)
-			expectTypeOf(Option.fromNullable('')).toEqualTypeOf<Option.Type<string>>()
+			expectTypeOf(Option.fromNullable<string | undefined>('')).toEqualTypeOf<
+				Option.Type<string>
+			>()
 
 			expect(Option.fromNullable([]).equals(Option.Some([]), equal)).toBe(true)
-			expectTypeOf(Option.fromNullable([])).toEqualTypeOf<Option.Type<never[]>>()
+			expectTypeOf(Option.fromNullable<undefined | number[]>([])).toEqualTypeOf<
+				Option.Type<number[]>
+			>()
 			expectTypeOf(Option.fromNullable(['foo'])).toEqualTypeOf<Option.Type<string[]>>()
 
 			const nullOption = Option.fromNullable(null)
@@ -286,14 +290,14 @@ describe('Option', () => {
 
 		test('static', () => {
 			Util.deepStrictEqual(pipe(Option.Some(1), Option.flatMap(f)), Option.Some(2))
-			Util.deepStrictEqual(pipe(Option.None<number>(), Option.flatMap(f)), Option.None())
+			Util.deepStrictEqual(pipe(Option.None(), Option.flatMap(f)), Option.None())
 			Util.deepStrictEqual(pipe(Option.Some(1), Option.flatMap(g)), Option.None())
 			Util.deepStrictEqual(pipe(Option.None(), Option.flatMap(g)), Option.None())
 		})
 
 		test('instance', () => {
 			Util.deepStrictEqual(Option.Some(1).flatMap(f), Option.Some(2))
-			Util.deepStrictEqual(Option.None<number>().flatMap(f), Option.None())
+			Util.deepStrictEqual(Option.None().flatMap(f), Option.None())
 			Util.deepStrictEqual(Option.Some(1).flatMap(g), Option.None())
 			Util.deepStrictEqual(Option.None().flatMap(g), Option.None())
 		})

--- a/src/option/option.ts
+++ b/src/option/option.ts
@@ -349,6 +349,61 @@ export abstract class Option<out A>
 	}
 
 	/**
+	 * Returns a curried function that, when invoked with an `Option<A>`, applies the provided function `f` to the value within the `Option` (if it exists) and wraps the result in a `Some`. If the `Option` is `None`, it returns `None`.
+	 * This is equivalent to:
+	 * ```ts
+	 * import { Option } from  './option.ts'
+	 * declare const option: Option.Type<unknown>
+	 * declare const f: <A, B>(a: A) => B
+	 *
+	 * option.match({
+	 * 	onSome: (x) => Option.Some(f(x)),
+	 * 	onNone: () => Option.None(),
+	 * })
+	 * ```
+	 *
+	 * @typeParam A - The type of the value within the `Option`.
+	 * @typeParam B - The type of the value that the function `f` returns.
+	 * @param f - The function to apply that has a type signature that goes from an `A` to  a `B`
+	 * @returns A curried function that takes an `Option<A>` and returns a new `Option<B>` with the result of applying `f` to the original `Option`'s value, if it was `Some`. If the original `Option` was `None`, it returns `None`.
+	 *
+	 *
+
+	 * @remarks
+	 * This method is curried to support partial application and pipelining. The `Option` instance to operate on is provided last.
+	 * This is similar to the instance method {@linkcode Option#map|map}, but is designed to be used in a functional programming style where data is provided last.
+	 * Unlike {@linkcode Option.flatMap|flatMap}, `f` does not need to return an `Option`; the result is automatically wrapped in a `Some`.
+	 *
+	 * @example
+	 * Operating on Some:
+	 * ```ts
+	 * import { pipe } from '../internal/function.ts'
+	 * import { Option } from './option.ts'
+	 *
+	 * const result = pipe(
+	 * 	Option.Some(5),
+	 * 	Option.map(value => value + 1)
+	 * 	)
+	 *
+	 * console.log(result) // Some(6)
+	 * ```
+	 *
+	 * @example
+	 *  Operating on None:
+	 *  ```ts
+	 *  import { Option } from './option.ts'
+	 *  import { pipe } from '../internal/function.ts'
+	 *
+	 *  const result = pipe(
+	 *  	Option.None(),
+	 *  	Option.map(value => value + 1)
+	 *  	)
+	 *
+	 *  console.log(result) // None
+	 *  ```
+	 *
+	 * @see Option.flatMap
+	 * @see Option.forEach
 	 * @see Option#map
 	 */
 	public static map: Covariant.Pipeable<Option.TypeLambda>['map'] =

--- a/src/option/option.ts
+++ b/src/option/option.ts
@@ -411,6 +411,34 @@ export abstract class Option<out A>
 			Option.isNone(self) ? Option.None() : Option.of(f(self.get()))
 
 	/**
+	 * Transform an `Option<A>` into an `Option<B>` by providing a transformation from `A` to `B` and one from `B` to `A`.
+	 * This method is curried, meaning it takes the transformation functions first and returns a new function that expects the `Option` instance.
+	 * This is its type signature:
+	 * ```ts no-eval no-assert
+	 * <A, B>(to: (a: A) => B, from: (b: B) => A) => <R, O, E>(self: Option.Type<A>) => Option.Type<B>
+	 * ```
+	 * @typeParam A - The source type of the value within the `Option`.
+	 * @typeParam B - The target type of the value within the `Option`.
+	 * @param to - The function  from `A` to `B` to apply to the value of the `Option` if it is nonempty.
+	 * @param from - The function from `B` to `A` to apply to the value of the `Option` if it is nonempty.
+	 * @returns A function that takes an `Option<A>` and returns an `Option<B>`.
+	 *
+	 * @example
+	 * ```ts
+	 * import { pipe } from '../internal/function.ts'
+	 * import { Option } from './option.ts'
+	 *
+	 * const to = (n: number): string => `Number is ${n}`
+	 * const from = (s: string): number => parseInt(s.split(' ')[2])
+	 *
+	 * const result = pipe(
+	 *   Option.Some(5),
+	 *   Option.imap(to, from)
+	 * );
+	 *
+	 * console.log(result); // Outputs: Some("Number is 5")
+	 * ```
+	 *
 	 * @see Option#imap
 	 */
 	public static imap: Covariant.Pipeable<Option.TypeLambda>['imap'] = Covariant.imap<

--- a/src/option/option.ts
+++ b/src/option/option.ts
@@ -676,6 +676,14 @@ export abstract class Option<out A>
 	}
 
 	/**
+	 * Transform an `Option<A>` into an `Option<B>` by providing a transformation from `A` to `B` and one from `B` to `A`.
+	 *
+	 * @typeParam A - The source type of the value within the `Option`.
+	 * @typeParam B - The target type of the value within the `Option`.
+	 * @param to - The function  from `A` to `B` to apply to the value of the `Option` if it is nonempty.
+	 * @param from - The function from `B` to `A` to apply to the value of the `Option` if it is nonempty.
+	 * @returns An `Option<B>` containing the result of applying `to` to the value of the `Option` if it is nonempty.
+	 *
 	 * @see Option.imap
 	 */
 	public imap<A, B>(this: Option.Type<A>, f: (a: A) => B, _g: (b: B) => A): Option.Type<B> {

--- a/src/option/option.ts
+++ b/src/option/option.ts
@@ -286,8 +286,8 @@ export abstract class Option<out A>
 	 */
 	public static fromNullable<T>(nullableValue: T): Option.Type<NonNullable<T>> {
 		return nullableValue === undefined || nullableValue === null
-			? None.getSingletonInstance<NonNullable<T>>()
-			: Option.Some(nullableValue as NonNullable<T>)
+			? None.getSingletonInstance()
+			: Option.Some(nullableValue)
 	}
 
 	/**

--- a/src/option/option.ts
+++ b/src/option/option.ts
@@ -143,21 +143,26 @@ export abstract class Option<out A>
 	 * For a more loose typing use cases, see {@link Option.of}.
 	 *
 	 * @example
+	 * non-null value
 	 * ```ts
 	 * import { Option } from './option.ts';
 	 *
 	 * // Wrapping a non-null value
-	 * const someValue = Option.Some(42);
+	 * const someValue = Option.Some(42)
 	 * //       ^?  Some<number>
+	 * ```
 	 *
-	 * // Attempting to wrap a nullable value will result in a compile-time error
-	 * const nullableValue: number | null = null;
+	 * @example
+	 * Attempting to wrap a nullable value will result in a compile-time error
+	 * ```ts
+	 * import { Option } from './option.ts';
+	 *
+	 * const nullableValue: number | null = null
 	 * // @ts-expect-error Argument of type 'null' is not assignable to parameter of type 'NonNullable<number>'
 	 * const optionValue = Option.Some(nullableValue)
 	 * //                                                       ^^^^^^^^^^^^^
 	 *
 	 * // Ensuring a non-null value
-	 * const nullableValue: number | null = null;
 	 * const safeValue = Option.Some(nullableValue ?? 0);
 	 * //        ^?  Some<number>
 	 * ```
@@ -202,7 +207,7 @@ export abstract class Option<out A>
 	 * declare const f: <A, B>(a: A) => B
 	 * declare const ifEmpty: <B>() => B
 	 *
-	 * option.map(f).getOrElse(ifEmpty())
+	 * option.map(f).getOrElse(ifEmpty)
 	 * ```
 	 *
 	 * @param ifEmpty - The expression to evaluate if empty.
@@ -353,8 +358,8 @@ export abstract class Option<out A>
 	 * This is equivalent to:
 	 * ```ts
 	 * import { Option } from  './option.ts'
-	 * declare const option: Option.Type<unknown>
-	 * declare const f: <A, B>(a: A) => B
+	 * declare const option: Option.Type<number>
+	 * declare const f: (a: number) => string
 	 *
 	 * option.match({
 	 * 	onSome: (x) => Option.Some(f(x)),
@@ -414,9 +419,7 @@ export abstract class Option<out A>
 	 * Transform an `Option<A>` into an `Option<B>` by providing a transformation from `A` to `B` and one from `B` to `A`.
 	 * This method is curried, meaning it takes the transformation functions first and returns a new function that expects the `Option` instance.
 	 * This is its type signature:
-	 * ```ts no-eval no-assert
-	 * <A, B>(to: (a: A) => B, from: (b: B) => A) => <R, O, E>(self: Option.Type<A>) => Option.Type<B>
-	 * ```
+	 * `<A, B>(to: (a: A) => B, from: (b: B) => A) => <R, O, E>(self: Option.Type<A>) => Option.Type<B>`
 	 * @typeParam A - The source type of the value within the `Option`.
 	 * @typeParam B - The target type of the value within the `Option`.
 	 * @param to - The function  from `A` to `B` to apply to the value of the `Option` if it is nonempty.
@@ -731,8 +734,8 @@ export abstract class Option<out A>
 	 * This is equivalent to:
 	 * ```ts
 	 * import { Option } from  './option.ts'
-	 * declare const option: Option.Type<unknown>
-	 * declare const f: <A, B>(a: A) => B
+	 * declare const option: Option.Type<Array<number>>
+	 * declare const f: (a: number[]) => boolean[]
 	 *
 	 * option.match({
 	 * 	onSome: (a) => Option.Some(f(a)), // Some<B>

--- a/src/option/option.ts
+++ b/src/option/option.ts
@@ -595,7 +595,7 @@ export abstract class Option<out A>
 	/**
 	 * @see Option.imap
 	 */
-	public imap<A, B>(this: Option.Type<A>, f: (a: A) => B, g: (b: B) => A): Option.Type<B> {
+	public imap<A, B>(this: Option.Type<A>, f: (a: A) => B, _g: (b: B) => A): Option.Type<B> {
 		return Option.map(f)(this)
 	}
 

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -1,13 +1,22 @@
 import { assertEquals, assertStrictEquals } from 'jsr:@std/assert'
 import type { Option } from '../option/option.ts'
 
-// deno-lint-ignore no-namespace
-export namespace Util {
-	export const deepStrictEqual = <A>(actual: A, expected: A) => {
+/**
+ * Utility class with helper methods for various test assertions.
+ */
+// biome-ignore lint/complexity/noStaticOnlyClass: <explanation>
+export class Util {
+	/**
+	 * Asserts that the actual value is equal to the expected value as well as their types.
+	 */
+	public static readonly deepStrictEqual = <A>(actual: A, expected: A) => {
 		assertEquals(actual, expected)
 	}
 
-	export const optionEqual = <A>(actual: Option.Type<A>, expected: Option.Type<A>) => {
+	/**
+	 * Compares two Option.Type instances for equality and asserts that they are equal.
+	 */
+	public static readonly optionEqual = <A>(actual: Option.Type<A>, expected: Option.Type<A>) => {
 		assertStrictEquals(actual.equals(expected), true)
 	}
 }

--- a/src/typeclass/covariant.ts
+++ b/src/typeclass/covariant.ts
@@ -38,16 +38,13 @@ export declare namespace Covariant {
 
 /**
  * Covariant companion object
- *
  */
 export const Covariant = {
 	/**
 	 * imap function for Covariant object
 	 */
-	imap:
-		<F extends TypeLambda>(
-			map: <A, B>(f: (a: A) => B) => <R, O, E>(self: Kind<F, R, O, E, A>) => Kind<F, R, O, E, B>,
-		): Invariant.Pipeable<F>['imap'] =>
-		(self, _to) =>
-			map(self),
+	imap: <F extends TypeLambda>(
+		map: <A, B>(f: (a: A) => B) => <R, O, E>(self: Kind<F, R, O, E, A>) => Kind<F, R, O, E, B>,
+	): Invariant.Pipeable<F>['imap'] =>
+	(self, _to) => map(self),
 } as const

--- a/src/typeclass/covariant.ts
+++ b/src/typeclass/covariant.ts
@@ -15,18 +15,39 @@ import type { Invariant } from './invariant.ts'
  * `fa.map(f).map(g) = fa.map(f.andThen(g))`
  */
 export declare namespace Covariant {
+	/**
+	 * Fluent interface for Covariant
+	 */
 	export interface Fluent<F extends TypeLambda> extends Invariant.Fluent<F> {
+		/**
+		 * Map function for Fluent interface
+		 */
 		map<R, O, E, A, B>(this: Kind<F, R, O, E, A>, f: (a: A) => B): Kind<F, R, O, E, B>
 	}
 
+	/**
+	 * Pipeable interface for Covariant
+	 */
 	export interface Pipeable<F extends TypeLambda> extends Invariant.Pipeable<F> {
+		/**
+		 * Map function for Pipeable interface
+		 */
 		map<A, B>(f: (a: A) => B): <R, O, E>(self: Kind<F, R, O, E, A>) => Kind<F, R, O, E, B>
 	}
 }
 
+/**
+ * Covariant companion object
+ *
+ */
 export const Covariant = {
-	imap: <F extends TypeLambda>(
-		map: <A, B>(f: (a: A) => B) => <R, O, E>(self: Kind<F, R, O, E, A>) => Kind<F, R, O, E, B>,
-	): Invariant.Pipeable<F>['imap'] =>
-	(self, _to) => map(self),
+	/**
+	 * imap function for Covariant object
+	 */
+	imap:
+		<F extends TypeLambda>(
+			map: <A, B>(f: (a: A) => B) => <R, O, E>(self: Kind<F, R, O, E, A>) => Kind<F, R, O, E, B>,
+		): Invariant.Pipeable<F>['imap'] =>
+		(self, _to) =>
+			map(self),
 } as const

--- a/src/typeclass/flat-map.ts
+++ b/src/typeclass/flat-map.ts
@@ -16,14 +16,30 @@ import type { Kind, TypeClass, TypeLambda } from '../internal/hkt.ts'
  * ```
  */
 export declare namespace FlatMap {
+	/**
+	 * Fluent interface for TypeClass
+	 * @template F TypeLambda
+	 */
 	export interface Fluent<F extends TypeLambda> extends TypeClass<F> {
+		/**
+		 * flatMap method
+		 * @template R1, O1, E1, A, R2, O2, E2, B
+		 */
 		flatMap<R1, O1, E1, A, R2, O2, E2, B>(
 			this: Kind<F, R1, O1, E1, A>,
 			f: (a: A) => Kind<F, R2, O2, E2, B>,
 		): Kind<F, R1 & R2, O1 | O2, E1 | E2, B>
 	}
 
+	/**
+	 * Pipeable interface for TypeClass
+	 * @template F TypeLambda
+	 */
 	export interface Pipeable<F extends TypeLambda> extends TypeClass<F> {
+		/**
+		 * readonly flatMap method
+		 * @template A, R2, O2, E2, B
+		 */
 		readonly flatMap: <A, R2, O2, E2, B>(
 			f: (a: A) => Kind<F, R2, O2, E2, B>,
 		) => <R1, O1, E1>(self: Kind<F, R1, O1, E1, A>) => Kind<F, R1 & R2, O1 | O2, E1 | E2, B>

--- a/src/typeclass/invariant.ts
+++ b/src/typeclass/invariant.ts
@@ -14,7 +14,13 @@ import type { Kind, TypeClass, TypeLambda } from '../internal/hkt.ts'
  * ```
  */
 export declare namespace Invariant {
+	/**
+	 * Fluent interface for Invariant
+	 */
 	export interface Fluent<F extends TypeLambda> extends TypeClass<F> {
+		/**
+		 * imap method for Fluent interface
+		 */
 		imap<R, O, E, A, B>(
 			this: Kind<F, R, O, E, A>,
 			to: (a: A) => B,
@@ -22,7 +28,13 @@ export declare namespace Invariant {
 		): Kind<F, R, O, E, B>
 	}
 
+	/**
+	 * Pipeable interface for Invariant
+	 */
 	export interface Pipeable<F extends TypeLambda> extends TypeClass<F> {
+		/**
+		 * imap method for Pipeable interface
+		 */
 		imap<A, B>(
 			to: (a: A) => B,
 			from: (b: B) => A,

--- a/src/typeclass/mod.ts
+++ b/src/typeclass/mod.ts
@@ -1,3 +1,39 @@
+/**
+ * This internal module provides a collection of re-usable type classes adapted from the `Scala's Cats` library and [`@effect/typeclass`](https://github.com/Effect-TS/effect/blob/184fed83ac36cba05a75a5a8013f740f9f696e3b/packages/typeclass/README.md).
+ *
+ * [!IMPORTANT]
+ * Credits to the original authors of the Scala Cats library and `@effect/typeclass`.
+ *
+ * **Parameterized Types Hierarchy**
+ *
+ * ```mermaid
+ * flowchart TD
+ *     Alternative --> SemiAlternative
+ *     Alternative --> Coproduct
+ *     Applicative --> Product
+ *     Coproduct --> SemiCoproduct
+ *     SemiAlternative --> Covariant
+ *     SemiAlternative --> SemiCoproduct
+ *     SemiApplicative --> SemiProduct
+ *     SemiApplicative --> Covariant
+ *     Applicative --> SemiApplicative
+ *     Chainable --> FlatMap
+ *     Chainable ---> Covariant
+ *     Monad --> FlatMap
+ *     Monad --> Pointed
+ *     Pointed --> Of
+ *     Pointed --> Covariant
+ *     Product --> SemiProduct
+ *     Product --> Of
+ *     SemiProduct --> Invariant
+ *     Covariant --> Invariant
+ *     SemiCoproduct --> Invariant
+ * ```
+ *
+ * @module
+ * @internal
+ */
+
 export type { FlatMap } from './flat-map.ts'
 export type { Invariant } from './invariant.ts'
 export { Covariant } from './covariant.ts'

--- a/src/typeclass/of.ts
+++ b/src/typeclass/of.ts
@@ -1,7 +1,29 @@
 import type { Kind, TypeClass, TypeLambda } from '../internal/hkt.ts'
 
+/**
+ * The `Of` type class is used to lifts any value into a context.
+ *
+ * | Name                      | Given   | To                    |
+ * |                                 |             |                          |
+ * | **of**                     | `A`      | `F<A>`             |
+ * | ~ofComposition~  | ~`A`~ | ~`F<G<A>>`~ |
+ * | ~unit~                    |            | ~`F<void>`~     |
+ * | ~Do~                     |            | ~`F<{}>`~          |
+ *
+ * @module
+ * @category typeclass
+ */
 export declare namespace Of {
+	/**
+	 * This is a Pipeable interface for TypeLambda.
+	 */
 	export interface Pipeable<F extends TypeLambda> extends TypeClass<F> {
+		/**
+		 * Lifts a value into the context.
+		 * @tpeParam A
+		 * @param  a - The value to lift into the context.
+		 * @returns the value lifted into the context.
+		 */
 		of<A>(a: A): Kind<F, unknown, never, never, A>
 	}
 }


### PR DESCRIPTION
This Pull Request revolves around the application of typeclasses to the Option class in the option.ts module. We've enriched the functionalities and relevant documentation of the Option class, laying focus on the following key updates:

- A transformation method imap has been added to the Option class. This method lets you transform an Option<A> into an Option<B>, by providing functions that can convert between types A and B, and vice versa.
- Detailed documentation has been created for the Option.imap instance method.
Option class have been further enhanced with the addition of a map static method. Comprehensive documentation has been appended to this new feature too.